### PR TITLE
Add `source` execution copy

### DIFF
--- a/docs/good-terminal.html
+++ b/docs/good-terminal.html
@@ -22,7 +22,7 @@
 
 		<p>I’m going to teach you how I like my terminal set up. These are hard-earned opinions. I advise you to start with my opinions until you have enough experience to develop your own.</p>
 
-		<p>This document was last updated on <b>19 MARCH 2022</b></p>
+		<p>This document was last updated on <b>13 SEPTEMBER 2023</b></p>
 
 
 		<h2>First, a note on documentation conventions</h2>

--- a/docs/what-the-path.html
+++ b/docs/what-the-path.html
@@ -19,7 +19,7 @@
 
 		<p>If you're running into the error <code>zsh: command not found</code>, this guide is for you.</p>
 
-		<p>This document was last updated on <b>03 MARCH 2021</b></p>
+		<p>This document was last updated on <b>13 SEPTEMBER 2023</b></p>
 
 
 		<h2>First, a word about executables</h2>

--- a/docs/what-the-path.html
+++ b/docs/what-the-path.html
@@ -100,7 +100,7 @@
 
 		<h2>What is “source”?</h2>
 
-		<p>When you make changes to shell files, you need to restart your shell in order for those changes to take effect. You could close your terminal and reopen it, or you can “source” the file that has the changes. To “source” the file, run <code>source ~/.zshrc</code> (or whatever file you need to source).</p>
+		<p>When you make changes to shell configuration files, you need them to be executed. To make those changes take effect you could close your terminal and reopen it, or you can “source” the file that has the changes. To “source” the file, run <code>source ~/.zshrc</code> (or whatever file you need to source).</p>
 
 		<p>If you add a directory to your <code>PATH</code> and then you try to run an executable in that directory and it still doesn’t work, you likely forgot to <code>source</code>.</p>
 


### PR DESCRIPTION
This includes an additional copy change re: `source` executing code. I would have included this in #2 if I'd noticed it sooner! I did my best to make a minimal change while leaving the majority of the copy structure as-is. 

This time I did `grep` the HTML source to see if I could find other related changes, I don't think I missed anything else.

This patch also updates the last-updated dates on the files changed here and in #2.